### PR TITLE
Fix Omnirom (aosp) build

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -11,7 +11,7 @@ LOCAL_MODULE_TAGS := eng debug optional
 LOCAL_FORCE_STATIC_EXECUTABLE := true
 LOCAL_STATIC_LIBRARIES := libc libcutils libselinux
 LOCAL_C_INCLUDES := external/sqlite/dist
-LOCAL_SRC_FILES := Superuser/jni/su/su.c Superuser/jni/su/daemon.c Superuser/jni/su/activity.c Superuser/jni/su/db.c Superuser/jni/su/utils.c Superuser/jni/su/pts.c Superuser/jni/sqlite3/sqlite3.c
+LOCAL_SRC_FILES := Superuser/jni/su/su.c Superuser/jni/su/daemon.c Superuser/jni/su/activity.c Superuser/jni/su/db.c Superuser/jni/su/utils.c Superuser/jni/su/pts.c Superuser/jni/sqlite3/sqlite3.c Superuser/jni/su/hacks.c Superuser/jni/su/binds.c
 LOCAL_CFLAGS := -DSQLITE_OMIT_LOAD_EXTENSION -DREQUESTOR=\"$(SUPERUSER_PACKAGE)\"
 
 ifdef SUPERUSER_PACKAGE_PREFIX

--- a/Superuser/jni/su/hacks.c
+++ b/Superuser/jni/su/hacks.c
@@ -19,9 +19,10 @@ static struct {
 
 void hacks_init() {
 	char oldCwd[512];
+	int i;
 	getcwd(oldCwd, sizeof(oldCwd));
 	chdir("/data/data");
-	for(int i=0; i<(sizeof(apps_list)/sizeof(apps_list[0])); ++i) {
+	for(i=0; i<(sizeof(apps_list)/sizeof(apps_list[0])); ++i) {
 		apps_list[i].uid = -1;
 		struct stat st_buf;
 		int ret = stat(apps_list[i].package, &st_buf);
@@ -33,7 +34,8 @@ void hacks_init() {
 }
 
 void hacks_update_context(struct su_context* ctxt) {
-	for(int i=0; i<(sizeof(apps_list)/sizeof(apps_list[0])); ++i) {
+	int i;
+	for(i=0; i<(sizeof(apps_list)/sizeof(apps_list[0])); ++i) {
 		LOGW("hacks: Testing (%s:%d), %d", apps_list[i].package, ctxt->from.uid);
 		if(apps_list[i].uid != ctxt->from.uid)
 			continue;


### PR DESCRIPTION
The error existed in the way the variables had been declared.
By moving the declaration outside of the for loop the problem is resolved.

I'm not sure if setting i=0 within the loop is ideal or if it's best done during the declaration.

This fixes Issue #8 